### PR TITLE
Let's make the sync a manual process

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,10 @@ excited about it just yet...
 
 ## How do I get a bugzilla bug to show up in waffle?
 
-You have three options:
-
-* File it under product="Cloud Services" and component="Server: Firefox Accounts" in bugzilla;
-  we mirror all bugs in that component by default.
+* Add "[fxa]" to the bug's "whiteboard" field.
 * Add "[fxa-waffle]" to the bug's "whiteboard" field.
-* Manually create the issue in the fxa-bugzilla-mirror repo, and put "[bzXXXXXXX]" in the title.
 
-All such bugs will be dealth with by the bug-syncing script.
+All such bugs will be dealt with by the bug-syncing script.
 The script runs automatically for public bugs every day!
 You can also run it by hand:
 

--- a/scripts/sync_bugs.js
+++ b/scripts/sync_bugs.js
@@ -18,8 +18,6 @@ var REPO = 'fxa'
 var BZ_URL = 'https://bugzilla.mozilla.org/rest'
 var BZ_VIEW_URL = 'https://bugzilla.mozilla.org/show_bug.cgi'
 var BZ_QUERIES = [
-  // Everything in "Cloud Services/Server: Firefox Accounts".
-  'product=Cloud%20Services&component=Server:%20Firefox%20Accounts',
   // Anything with [fxa] in its whiteboard string.
   'whiteboard=[fxa]',
   // Anything with [fxa-waffle] in its whiteboard string.


### PR DESCRIPTION
What do you think of getting rid of the automatic sync?  I find I mostly just set an ignore flag and close them on the github side.